### PR TITLE
Ensure database tables exist before running server

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -1,5 +1,6 @@
 import os
-from tsundiary import app
+from tsundiary import app, ensure_db_exists
 
 PORT = int(os.environ.get('PORT', 5000))
+ensure_db_exists()
 app.run(host='0.0.0.0', port=PORT, debug=os.environ.get('DEBUG') or False)

--- a/tsundiary/__init__.py
+++ b/tsundiary/__init__.py
@@ -32,7 +32,7 @@ app.permanent_session_lifetime = timedelta(days=90)
 
 # Import the rest of the tsundiary stuff
 from tsundiary.views import *
-from tsundiary.models import User, db
+from tsundiary.models import User, db, ensure_db_exists
 from tsundiary.utils import their_date
 import tsundiary.jinja_env
 

--- a/tsundiary/models.py
+++ b/tsundiary/models.py
@@ -104,6 +104,9 @@ def init_db():
     db.drop_all()
     db.create_all()
 
+def ensure_db_exists():
+    db.create_all()
+
 def populate_db():
     admin = User("admin", "cake")
     bob = User("bob", "yolo")


### PR DESCRIPTION
I made these changes to make it easier when starting up a server on my local machine. I'm not sure how it would interact with the hosted solution, (messing up database upgrades?), but I can't see it being an issue. Otherwise, could create a script that just inits the database.
